### PR TITLE
n3 + browser compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+src/schemas/index.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,10 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@rdfjs/formats-common": "^3.1.0",
-        "@types/rdfjs__formats-common": "^3.1.5",
-        "@zazuko/env-node": "^2.1.4",
-        "chai": "^5.1.2",
+        "@zazuko/env": "^2.4.2",
         "ethers": "^6.15.0",
+        "jsonld": "^8.3.3",
+        "n3": "^1.23.1",
         "rdf-literal": "^2.0.0",
         "rdf-validate-shacl": "^0.5.6"
       },
@@ -22,6 +21,9 @@
         "@types/mocha": "^10.0.10",
         "@typescript-eslint/eslint-plugin": "^6.4.1",
         "@typescript-eslint/parser": "^6.4.1",
+        "@zazuko/env-node": "^3.0.0",
+        "@zazuko/rdf-utils-fs": "^3.3.1",
+        "chai": "^5.1.2",
         "eslint": "^8.57.0",
         "eslint-config-oceanprotocol": "^2.0.3",
         "eslint-config-prettier": "^9.0.0",
@@ -2886,9 +2888,9 @@
       }
     },
     "node_modules/@rdfjs/data-model": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.2.tgz",
-      "integrity": "sha512-v5LRNkLRJazMCGU7VtEzhz5wKwz/IrOdJEKapCtd35HuFbQfeGpoJP6QOXGyFHhWwKmtG+UMlZzYFyNDVE1m6g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.1.1.tgz",
+      "integrity": "sha512-6mcOI4DjIPS6MOZw23H8oAdujHCk5gippVNQ7mKwliYTvTNh+uqRM91B9OLqhoAoNcQ3t49Dx2ooIMRG9/6ooA==",
       "license": "MIT",
       "bin": {
         "rdfjs-data-model-test": "bin/test.js"
@@ -2913,6 +2915,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@rdfjs/fetch-lite/-/fetch-lite-3.3.0.tgz",
       "integrity": "sha512-K3hZC4+Ch0UmYA1w0Xv/8cCVPD5ulKwRa6A/iTn3BFbZpVAb5KoBfOfnOhe6VJEa50raUvTHR1gp1YdvUnYt9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-stream": "^4.0.1",
@@ -2934,30 +2937,6 @@
         "@rdfjs/serializer-turtle": "^1.1.1",
         "@rdfjs/sink-map": "^2.0.0",
         "rdfxml-streaming-parser": "^3.0.1"
-      }
-    },
-    "node_modules/@rdfjs/formats-common": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/formats-common/-/formats-common-3.1.0.tgz",
-      "integrity": "sha512-wgz5za/Uls+pttLdLl/aH0m0LQNgjqpWwk9exNs2Smmb2CosynRo4S0+CxeNOVZh4zeUm7oAlr1CK/tyg4Ff6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/parser-jsonld": "^2.0.0",
-        "@rdfjs/parser-n3": "^2.0.0",
-        "@rdfjs/serializer-jsonld": "^2.0.0",
-        "@rdfjs/serializer-ntriples": "^2.0.0",
-        "@rdfjs/sink-map": "^2.0.0",
-        "rdfxml-streaming-parser": "^2.2.0"
-      }
-    },
-    "node_modules/@rdfjs/formats/node_modules/@types/readable-stream": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.18.tgz",
-      "integrity": "sha512-21jK/1j+Wg+7jVw1xnSwy/2Q1VgVjWuFssbYGTREPUBeZ+rqVFl2udq0IkxzPC0ZhOzVceUbyIACFZKLqKEBlA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "safe-buffer": "~5.1.1"
       }
     },
     "node_modules/@rdfjs/formats/node_modules/rdfxml-streaming-parser": {
@@ -3131,9 +3110,9 @@
       }
     },
     "node_modules/@rdfjs/types": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3492,7 +3471,8 @@
       "version": "1.5.15",
       "resolved": "https://registry.npmjs.org/@types/jsonld/-/jsonld-1.5.15.tgz",
       "integrity": "sha512-PlAFPZjL+AuGYmwlqwKEL0IMP8M8RexH0NIPGfCVWSQ041H2rR/8OlyZSD7KsCVoN8vCfWdtWDBxX8yBVP+xow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
@@ -3536,13 +3516,13 @@
       }
     },
     "node_modules/@types/rdfjs__data-model": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__data-model/-/rdfjs__data-model-2.0.8.tgz",
-      "integrity": "sha512-7OVjhmA8QPEdRReHFieKuqn2mbYx3ndEIEmh/6FkeJC8QCMJGVeSuRKEUVXbZGwP0rDKZuhQGozaRv3O1z1gPQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__data-model/-/rdfjs__data-model-2.0.9.tgz",
+      "integrity": "sha512-rgQSlM9jr7XMZdC0xUIr0zsxf5FvdB4cxxzv+MlHm6uJGip5qi0q+BluNhakAzaM2I56nKLDqSE3I/XuOaHGnA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@rdfjs/types": "^1.0.1"
+        "@rdfjs/types": "*"
       }
     },
     "node_modules/@types/rdfjs__dataset": {
@@ -3570,6 +3550,7 @@
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__fetch-lite/-/rdfjs__fetch-lite-3.0.11.tgz",
       "integrity": "sha512-1bHxBn62bmTPq/HY9Jr+iKCdBp8RTEJ4WA0ycihghRF8zWQfw6T7E5CqdPi4nncmgF70LOz7jF/4jeLGdb6H2A==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3597,22 +3578,6 @@
         "rdfxml-streaming-parser": ">=2"
       }
     },
-    "node_modules/@types/rdfjs__formats-common": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__formats-common/-/rdfjs__formats-common-3.1.5.tgz",
-      "integrity": "sha512-Zt74nSd9NemOq90/2cMrBVwnHJIXHFFDS7tkY4Slei1eRoQJpws059Lx9O+mqaFspkD3r81Enu/5CiNfQg9V7g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": ">=1.0.0",
-        "@types/node": "*",
-        "@types/rdfjs__parser-jsonld": "*",
-        "@types/rdfjs__parser-n3": "*",
-        "@types/rdfjs__serializer-jsonld": "*",
-        "@types/rdfjs__serializer-ntriples": "*",
-        "@types/rdfjs__sink-map": "*",
-        "rdfxml-streaming-parser": ">=2"
-      }
-    },
     "node_modules/@types/rdfjs__namespace": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__namespace/-/rdfjs__namespace-2.0.10.tgz",
@@ -3627,6 +3592,7 @@
       "resolved": "https://registry.npmjs.org/@types/rdfjs__parser-jsonld/-/rdfjs__parser-jsonld-2.1.7.tgz",
       "integrity": "sha512-n35K+c1Y95580N202Jxly6xjFE953FF+Y2mwxok6zLfMo4rgIfgMBElnNwpja0IeYXTuzGm1tEz7va3lItGrTg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rdfjs/types": ">=1.0.0",
         "@types/jsonld": "*"
@@ -3637,6 +3603,7 @@
       "resolved": "https://registry.npmjs.org/@types/rdfjs__parser-n3/-/rdfjs__parser-n3-2.0.6.tgz",
       "integrity": "sha512-VHfdq7BDV6iMCtHkzTFSOuUWnqGlMUmEF0UZyK4+g9SzLWvc6TMcU5TYwQPQIz/e0s7dZ+xomxx6mVtIzsRQ/A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rdfjs/types": ">=1.0.0"
       }
@@ -3656,6 +3623,7 @@
       "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-jsonld/-/rdfjs__serializer-jsonld-2.0.5.tgz",
       "integrity": "sha512-ubdLD9QgZzAt+65NSPzh2qWCPWcGYlHEWgkP6uRwfm7JC48Xh/QjzwOTG13MTomOkQqcN4R7PIG0j3Ca8iyNWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rdfjs/types": ">=1.0.0"
       }
@@ -3677,6 +3645,7 @@
       "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-ntriples/-/rdfjs__serializer-ntriples-2.0.6.tgz",
       "integrity": "sha512-Nn3e3eyuymLvbI5MFzI7ODD/X6ZGpbB9fLaWOB00RtFHd2vttk3wQL2fzzsZZQPJ/ihC/xlFE4cNQkO6SoHa7w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rdfjs/types": ">=1.0.0"
       }
@@ -3698,6 +3667,7 @@
       "resolved": "https://registry.npmjs.org/@types/rdfjs__sink-map/-/rdfjs__sink-map-2.0.5.tgz",
       "integrity": "sha512-ycUBlOMbp9YpjrBrMwGv3uiqulOWgodess06cinYLxomOTc2ET9rEQklgM5rJqnu5WMsVP8SFG3fFw36/5hADQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rdfjs/types": "*"
       }
@@ -3733,13 +3703,12 @@
       }
     },
     "node_modules/@types/readable-stream": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
-      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.23.tgz",
+      "integrity": "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "*",
-        "safe-buffer": "~5.1.1"
+        "@types/node": "*"
       }
     },
     "node_modules/@types/resolve": {
@@ -3965,18 +3934,18 @@
       "license": "ISC"
     },
     "node_modules/@vocabulary/sh": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@vocabulary/sh/-/sh-1.1.5.tgz",
-      "integrity": "sha512-8R4uxHLpwmp6l6szZdCtfQx0wRy64OHuOsYTDfhCsbJ773Uv6nCM2bYBtjjirZHN+2m3uHQWgtWOdvuu1jwmOA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@vocabulary/sh/-/sh-1.1.6.tgz",
+      "integrity": "sha512-8IfAQoKh57THz8LA2+n1jaY/VC2XaqMNSsJgzBKSSrj20y5PSMAawb6dMsxoLxqDIPBDs1TFRl/9CijUnwbBUA==",
       "license": "MIT",
       "peerDependencies": {
-        "@rdfjs/types": "^1.0.0"
+        "@rdfjs/types": "^2.0.0"
       }
     },
     "node_modules/@zazuko/env": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@zazuko/env/-/env-2.4.2.tgz",
-      "integrity": "sha512-mq3YTIs9dmXh2nyS2Hm94bNRHuItlgrp+5QS1zG6ClSpmgztKhMYNRhssmZvd0kBcpYZSV4+EogI/QxrkCg6ww==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@zazuko/env/-/env-2.5.3.tgz",
+      "integrity": "sha512-kivvYoXGFjva1CuXeK/jaaWMy9eXhhFmuSfSJGVW2wH7XbcZehJObjPXEVlZ3kKLCFhuv96j8Ot3SkbYaOtuLA==",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/data-model": "^2.0.1",
@@ -3994,17 +3963,17 @@
         "rdf-dataset-ext": "^1.1.0"
       },
       "peerDependencies": {
-        "@rdfjs/types": "^1.1.0",
+        "@rdfjs/types": "^2",
         "@types/clownface": "^2.0.0",
-        "@types/rdf-dataset-ext": "^1",
-        "@types/rdfjs__data-model": "^2.0.7",
+        "@types/rdf-dataset-ext": "^1.0.8",
+        "@types/rdfjs__data-model": "^2.0.9",
         "@types/rdfjs__dataset": "^2.0.7",
         "@types/rdfjs__environment": "^1.0.0",
-        "@types/rdfjs__formats": "^4.0.0",
+        "@types/rdfjs__formats": "^4.0.1",
         "@types/rdfjs__namespace": "^2.0.10",
-        "@types/rdfjs__term-map": "^2.0.9",
-        "@types/rdfjs__term-set": "^2.0.8",
-        "@types/rdfjs__traverser": "^0.1.3"
+        "@types/rdfjs__term-map": "^2.0.10",
+        "@types/rdfjs__term-set": "^2.0.9",
+        "@types/rdfjs__traverser": "^0.1.5"
       }
     },
     "node_modules/@zazuko/env-core": {
@@ -4019,31 +3988,82 @@
       }
     },
     "node_modules/@zazuko/env-node": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@zazuko/env-node/-/env-node-2.1.4.tgz",
-      "integrity": "sha512-D3pw3T3SpC6lI3D5Akio/63lWaI9VKWazVGcjWP0gC598JQ60V7T+4QSCUcxT0ZGTDOkNdT3loYR9P+JK96KeQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@zazuko/env-node/-/env-node-3.0.0.tgz",
+      "integrity": "sha512-51Kuamvezf6b4JHa3QZWoxMhtNYhdaUD1ITRPpwppZVg/5CR/C92QLCR6dlpKX6vyUcrbpnT+1saXVgADiUiSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/fetch-lite": "^3.2.2",
         "@rdfjs/formats": "^4.0.0",
-        "@zazuko/env": "^2.1.1",
+        "@zazuko/env": "^3.0.0",
         "@zazuko/rdf-utils-fs": "^3.3.0"
       },
       "peerDependencies": {
-        "@types/rdfjs__fetch-lite": "^3.0.6",
-        "@types/rdfjs__formats": "^4"
+        "@types/rdfjs__fetch-lite": "^3.0.11",
+        "@types/rdfjs__formats": "^4.0.1"
+      }
+    },
+    "node_modules/@zazuko/env-node/node_modules/@tpluscode/rdf-ns-builders": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-ns-builders/-/rdf-ns-builders-5.0.0.tgz",
+      "integrity": "sha512-rtMFbArdief+s0z2A3TOb/gNe5O5xn9LDiEpilCf6lGYCUIfyqoOvZY80fS/eILwcF2Mj6cUQN1WBQ+1neJmaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/data-model": "^2.1.0",
+        "@rdfjs/namespace": "^2.0.1",
+        "@rdfjs/types": "^2",
+        "@types/rdfjs__namespace": "^2.0.10",
+        "@zazuko/prefixes": "^2.3.0"
+      }
+    },
+    "node_modules/@zazuko/env-node/node_modules/@zazuko/env": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@zazuko/env/-/env-3.0.1.tgz",
+      "integrity": "sha512-EMRTgMXXbBIw9Zh6s6JPB16/6hNd0IZ4tcQZbr88K3RwtX3Eza3JfRCTPwtY/iNKOMWzG2e/dkPswWwxU+Ic6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/data-model": "^2.0.1",
+        "@rdfjs/dataset": "^2.0.1",
+        "@rdfjs/formats": "^4.0.0",
+        "@rdfjs/namespace": "^2.0.0",
+        "@rdfjs/term-map": "^2.0.0",
+        "@rdfjs/term-set": "^2.0.1",
+        "@rdfjs/traverser": "^0.1.2",
+        "@tpluscode/rdf-ns-builders": "^5",
+        "@zazuko/env-core": "^1.1.2",
+        "@zazuko/prefixes": "^2.1.0",
+        "clownface": "^2.0.2",
+        "get-stream": "^9.0.1",
+        "rdf-dataset-ext": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@rdfjs/types": "^2",
+        "@types/clownface": "^2.0.0",
+        "@types/rdf-dataset-ext": "^1.0.8",
+        "@types/rdfjs__data-model": "^2.0.9",
+        "@types/rdfjs__dataset": "^2.0.7",
+        "@types/rdfjs__environment": "^1.0.0",
+        "@types/rdfjs__formats": "^4.0.1",
+        "@types/rdfjs__namespace": "^2.0.10",
+        "@types/rdfjs__term-map": "^2.0.10",
+        "@types/rdfjs__term-set": "^2.0.9",
+        "@types/rdfjs__traverser": "^0.1.5"
       }
     },
     "node_modules/@zazuko/prefixes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@zazuko/prefixes/-/prefixes-2.2.0.tgz",
-      "integrity": "sha512-mmRS+urGVMcAP5edzFq0V+B2PbbpEklP7BZGVF0+82ClczTwgpIL1tZy2mRfudwRYoAe+WkyWXDnlArPpdzLIg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@zazuko/prefixes/-/prefixes-2.6.1.tgz",
+      "integrity": "sha512-fbOadP7twxt0ZYT9mgIC+xQMk6f3pYYLI5a/2UJ/mc/ygqb/NoVv2ryK3lTtoi74xwkdpUeDwIuFQSosowzUgg==",
       "license": "MIT"
     },
     "node_modules/@zazuko/rdf-utils-fs": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@zazuko/rdf-utils-fs/-/rdf-utils-fs-3.3.1.tgz",
       "integrity": "sha512-4HjTbJUwiCFanMMcaaZkLIkWUdVjXSQstAyxnfzsUOmh8Q43iVBL+mYAl17zoi47III0POL6hitRsN1JJ5tUFg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": ">=3.6.0"
@@ -4445,6 +4465,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5015,6 +5036,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
       "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "assertion-error": "^2.0.1",
@@ -5055,6 +5077,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
       "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -5665,6 +5688,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9133,16 +9157,6 @@
         "url": "https://github.com/sponsors/rubensworks/"
       }
     },
-    "node_modules/jsonld-streaming-parser/node_modules/@types/readable-stream": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.18.tgz",
-      "integrity": "sha512-21jK/1j+Wg+7jVw1xnSwy/2Q1VgVjWuFssbYGTREPUBeZ+rqVFl2udq0IkxzPC0ZhOzVceUbyIACFZKLqKEBlA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "safe-buffer": "~5.1.1"
-      }
-    },
     "node_modules/jsonld/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -9301,6 +9315,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -9407,6 +9422,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
       "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -10100,6 +10116,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/nodeify-fetch/-/nodeify-fetch-3.1.0.tgz",
       "integrity": "sha512-ZV81vM//sEgTgXwVZlOONzcOCdTGQ53mV65FVSNXgPQHa8oCwRLtLbnGxL/1S/Yw90bcXUDKMz00jEnaeazo+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
@@ -10783,6 +10800,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
       "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
@@ -11814,15 +11832,6 @@
         "url": "https://github.com/sponsors/rubensworks/"
       }
     },
-    "node_modules/rdf-data-factory/node_modules/@rdfjs/types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
-      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/rdf-dataset-ext": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/rdf-dataset-ext/-/rdf-dataset-ext-1.1.0.tgz",
@@ -11875,6 +11884,15 @@
         "rdf-validate-datatype": "^0.2.0"
       }
     },
+    "node_modules/rdf-validate-shacl/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/rdf-validate-shacl/node_modules/rdf-data-factory": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
@@ -11899,6 +11917,7 @@
       "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.4.0.tgz",
       "integrity": "sha512-f+tdI1wxOiPzMbFWRtOwinwPsqac0WIN80668yFKcVdFCSTGOWTM70ucQGUSdDZZo7pce/UvZgV0C3LDj0P7tg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rdfjs/types": "*",
         "@rubensworks/saxes": "^6.0.1",
@@ -11910,11 +11929,23 @@
         "validate-iri": "^1.0.0"
       }
     },
+    "node_modules/rdfxml-streaming-parser/node_modules/@types/readable-stream": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
+    },
     "node_modules/rdfxml-streaming-parser/node_modules/rdf-data-factory": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz",
       "integrity": "sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rdfjs/types": "*"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@zazuko/env": "^2.4.2",
         "ethers": "^6.15.0",
         "jsonld": "^8.3.3",
         "n3": "^1.23.1",
@@ -1811,6 +1810,7 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@bergos/jsonparse/-/jsonparse-1.4.2.tgz",
       "integrity": "sha512-qUt0QNJjvg4s1zk+AuLM6s/zcsQ8MvGn7+1f0vPuxvpCYa08YtTryuDInngbEyW5fNGGYe2znKt61RMGd5HnXg==",
+      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
@@ -2927,6 +2927,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/formats/-/formats-4.0.1.tgz",
       "integrity": "sha512-Rg53vP+x1bnGAqJNKgEzJEUPDhj+tCpzb6wdmfLoVFq4XoZ589+cg2ScFDUMMyAVsgKXvSWjDhQ9f9ab254ZxA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/parser-jsonld": "^2.1.0",
@@ -2943,6 +2944,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-3.0.1.tgz",
       "integrity": "sha512-lJtJ85xEJHc5BXohOPtxjYMEbGK3uiRxROwJLVNGanjuKLT9BWJluoNr3RzS9vQNmjkQwhhYmrbIftw1WUOj7Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rubensworks/saxes": "^6.0.1",
@@ -2971,6 +2973,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@rdfjs/parser-jsonld/-/parser-jsonld-2.1.3.tgz",
       "integrity": "sha512-VYnPEwVdqFAPTo9F8XIN4UpGPdNzhBaCFv5b5OT74pA7H8so4aTno3Yd6M5I9bhTrUoCQjpjgr+ugYlvWxdBIA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/data-model": "^2.0.2",
@@ -2984,6 +2987,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@rdfjs/parser-n3/-/parser-n3-2.0.2.tgz",
       "integrity": "sha512-rrrvyh+kkj9ndwep2h6nYmugIfggDOC9uGpmDAHn/I/z52K7dHxi7xOkPPrezTsIbgNvFhV3zS7mzyObRxcLWA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/data-model": "^2.0.2",
@@ -2997,6 +3001,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@rdfjs/prefix-map/-/prefix-map-0.1.2.tgz",
       "integrity": "sha512-qapFYVPYyYepg0sFy7T512667iZsN9a3RNcyNBTBV+O8wrU3v/URQZOipCTNrEm1BXzZ7KCK1Yi8HrE1y+uRuQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "^4.3.0"
@@ -3006,6 +3011,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/serializer-jsonld/-/serializer-jsonld-2.0.1.tgz",
       "integrity": "sha512-O8WzdY7THsse/nMsrMLd2e51ADHO2SIUrkiZ9Va/8W3lXeeeiwDRPMppWy/i9yL4q6EM8iMW1riV7E0mK3fsBQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/sink": "^2.0.1",
@@ -3016,6 +3022,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@rdfjs/serializer-jsonld-ext/-/serializer-jsonld-ext-4.0.0.tgz",
       "integrity": "sha512-HP5DCmhyfVuQuk58AO5vzNY+dIFVHe2oHY8NX2K+3XmrTmu/yzrFzPbDeU9Cwr71XC4RifEMoksIg+8jnhxmfQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/sink": "^2.0.0",
@@ -3028,6 +3035,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/serializer-ntriples/-/serializer-ntriples-2.0.1.tgz",
       "integrity": "sha512-G1ZI0qaN/MUHxeCwr59JscO2LdyIb6MNQdXOv7NFBZuodyHsxxhJRFmMVn+3SEXeNJbVeEEbWBrLglCUgJ8XjQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/sink": "^2.0.1",
@@ -3040,6 +3048,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@rdfjs/serializer-turtle/-/serializer-turtle-1.1.4.tgz",
       "integrity": "sha512-fw58pfAuIZblNzf8Gwl6mxfNkPH+/4Q1GwF0GFaSHg9yT0sQ1S+EzaqEVXl0MLPquEKTAMJFBs1fkdwUNq8Qww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/data-model": "^2.0.1",
@@ -3057,12 +3066,14 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/sink/-/sink-2.0.1.tgz",
       "integrity": "sha512-smzIFGF6EH1sLAJR9F3p2wMNrN44JjPeYAoITTJLqtuNC319K7IXaJ+qNLBGTtapZ/jvpx2Tks0TjcH9KrAvEA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rdfjs/sink-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/sink-map/-/sink-map-2.0.1.tgz",
       "integrity": "sha512-BwCTTsMN/tfQl6QzD2oHn9A08e4af+hlzAz/d5XXrlOkYMEDUAqFuh2Odj9EbayhAEeN4wA743Mj2yC0/s69rg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rdfjs/term-map": {
@@ -3093,6 +3104,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@rdfjs/traverser/-/traverser-0.1.4.tgz",
       "integrity": "sha512-53QYlxiQIxH8k4jutjet1EjdZfyKCDSsfqnj2YejAJ1X8mLDMSOsneMM5savBwBR0ROfAhKVtZVb+pego+JLiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/to-ntriples": "^3.0.1"
@@ -3102,6 +3114,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/tree/-/tree-0.2.1.tgz",
       "integrity": "sha512-J70CQ7R8Ivfs1FFUxtFN7ADb5wTMgbhn0O558NXSXQHItmSavT6cXmQlIokbmboU+grhu56iR/8Bl9do8LCq+w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/namespace": "^2.0.0",
@@ -3250,6 +3263,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@rubensworks/saxes/-/saxes-6.0.1.tgz",
       "integrity": "sha512-UW4OTIsOtJ5KSXo2Tchi4lhZqu+tlHrOAs4nNti7CrtB53kAZl3/hyrTi6HkMihxdbDM6m2Zc3swc/ZewEe1xw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -3262,6 +3276,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sindresorhus/merge-streams": {
@@ -3423,6 +3438,7 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@types/clownface/-/clownface-2.0.8.tgz",
       "integrity": "sha512-vomfitsRIuvw9zp/Xph8/AHPRBQ+7Ji/OnQUC3TOem+KzG/z2rCeEjpZH23wP7t0gjXZHPiZU1syFkf/oP3v8w==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3448,6 +3464,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.7.tgz",
       "integrity": "sha512-snm5oLckop0K3cTDAiBnZDy6ncx9DJ3mCRDvs42C884MbVYPP74Tiq2hFsSDRTyjK6RyDYDIulPiW23ge+g5Lw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3471,6 +3488,7 @@
       "version": "1.5.15",
       "resolved": "https://registry.npmjs.org/@types/jsonld/-/jsonld-1.5.15.tgz",
       "integrity": "sha512-PlAFPZjL+AuGYmwlqwKEL0IMP8M8RexH0NIPGfCVWSQ041H2rR/8OlyZSD7KsCVoN8vCfWdtWDBxX8yBVP+xow==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -3508,6 +3526,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/rdf-dataset-ext/-/rdf-dataset-ext-1.0.8.tgz",
       "integrity": "sha512-ngMGOzAm+yvrfTzFhlmPNa9lfWO72IkdqYRR+HNIPX3x+RPLf6qRpAi8GAZCg0rkpGt2JJqDQF3FgVxE6ykr/w==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3519,6 +3538,7 @@
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__data-model/-/rdfjs__data-model-2.0.9.tgz",
       "integrity": "sha512-rgQSlM9jr7XMZdC0xUIr0zsxf5FvdB4cxxzv+MlHm6uJGip5qi0q+BluNhakAzaM2I56nKLDqSE3I/XuOaHGnA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3529,6 +3549,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__dataset/-/rdfjs__dataset-2.0.7.tgz",
       "integrity": "sha512-+GaYIL9C7N1N0HyH+obU4IXuL7DX+fXuf827aUQ2Vx2UghO47+OTxo2v3seEQj/1YHoHBfQFk5Y4P6Q7Ht4Hqw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3539,6 +3560,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__environment/-/rdfjs__environment-1.0.0.tgz",
       "integrity": "sha512-MDcnv3qfJvbHoEpUQXj5muT8g3e+xz1D8sGevrq3+Q4TzeEvQf5ijGX5l8485XFYrN/OBApgzXkHMZC04/kd5w==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3563,6 +3585,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__formats/-/rdfjs__formats-4.0.1.tgz",
       "integrity": "sha512-Zj7hQEn5HeCj+pJCWshY2gqBcdBdwyc2j20Ht3PH91pkdRuG2AlGDD3N9PQ1oZ3+J6Q96rAlhxUbjQUp9+s3FQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3591,6 +3614,7 @@
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__parser-jsonld/-/rdfjs__parser-jsonld-2.1.7.tgz",
       "integrity": "sha512-n35K+c1Y95580N202Jxly6xjFE953FF+Y2mwxok6zLfMo4rgIfgMBElnNwpja0IeYXTuzGm1tEz7va3lItGrTg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3602,6 +3626,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__parser-n3/-/rdfjs__parser-n3-2.0.6.tgz",
       "integrity": "sha512-VHfdq7BDV6iMCtHkzTFSOuUWnqGlMUmEF0UZyK4+g9SzLWvc6TMcU5TYwQPQIz/e0s7dZ+xomxx6mVtIzsRQ/A==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3612,6 +3637,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__prefix-map/-/rdfjs__prefix-map-0.1.5.tgz",
       "integrity": "sha512-RAwyS/2dT9X79QwM0F8KLweTfuBoe6xtiAlU7wKPB+/t/sfk6A50LYtAWaDVP5qBjcu50UkKkZT+VR47CiLkfg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3622,6 +3648,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-jsonld/-/rdfjs__serializer-jsonld-2.0.5.tgz",
       "integrity": "sha512-ubdLD9QgZzAt+65NSPzh2qWCPWcGYlHEWgkP6uRwfm7JC48Xh/QjzwOTG13MTomOkQqcN4R7PIG0j3Ca8iyNWQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3632,6 +3659,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-jsonld-ext/-/rdfjs__serializer-jsonld-ext-4.0.1.tgz",
       "integrity": "sha512-jgbQ/1kV7nESKG7SY8FJED6K4OFznr6Sz3ybF1ncpBR7TUBTuy3InpZOVRK4Wjpy2zi84iIAzJ1CIIo9NZh2Xw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3644,6 +3672,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-ntriples/-/rdfjs__serializer-ntriples-2.0.6.tgz",
       "integrity": "sha512-Nn3e3eyuymLvbI5MFzI7ODD/X6ZGpbB9fLaWOB00RtFHd2vttk3wQL2fzzsZZQPJ/ihC/xlFE4cNQkO6SoHa7w==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3654,6 +3683,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-turtle/-/rdfjs__serializer-turtle-1.1.0.tgz",
       "integrity": "sha512-NGHnbz5985UwS/YS6WL/FkS94B+QiVTdsfvJCqPwLmY3E7UeClw91c2KbiphZUR/uh7uwLwxeKKhV2T1gYgT5Q==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3666,6 +3696,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__sink-map/-/rdfjs__sink-map-2.0.5.tgz",
       "integrity": "sha512-ycUBlOMbp9YpjrBrMwGv3uiqulOWgodess06cinYLxomOTc2ET9rEQklgM5rJqnu5WMsVP8SFG3fFw36/5hADQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3676,6 +3707,7 @@
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__term-map/-/rdfjs__term-map-2.0.10.tgz",
       "integrity": "sha512-YlpYkya+Xq9fmcw+BMi1SCh+w2sBu7G0/qd2+ZhB4QIK3V1xq2o3EOAZnlahyQdwrW9t5+Ihw8IVVvZsJvDOTA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3686,6 +3718,7 @@
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__term-set/-/rdfjs__term-set-2.0.9.tgz",
       "integrity": "sha512-RRXs5DwFGanZyT705f7KLSiN68gUVUtGWTp508CXJhLfD7AWmilqc1BLgLUoac48h3pnh9w5lRhwFm6fj1ZE5Q==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3696,6 +3729,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__traverser/-/rdfjs__traverser-0.1.5.tgz",
       "integrity": "sha512-tTpiM6lAddw+bGRDjhzwdpo1EQK73m8gYgMVNfO4OsevnuLZvQJeCJBckpuDC4H5HVAEwCapI0UlH9dVnZ9u5g==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3706,6 +3740,7 @@
       "version": "4.0.23",
       "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.23.tgz",
       "integrity": "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3942,44 +3977,11 @@
         "@rdfjs/types": "^2.0.0"
       }
     },
-    "node_modules/@zazuko/env": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@zazuko/env/-/env-2.5.3.tgz",
-      "integrity": "sha512-kivvYoXGFjva1CuXeK/jaaWMy9eXhhFmuSfSJGVW2wH7XbcZehJObjPXEVlZ3kKLCFhuv96j8Ot3SkbYaOtuLA==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/data-model": "^2.0.1",
-        "@rdfjs/dataset": "^2.0.1",
-        "@rdfjs/formats": "^4.0.0",
-        "@rdfjs/namespace": "^2.0.0",
-        "@rdfjs/term-map": "^2.0.0",
-        "@rdfjs/term-set": "^2.0.1",
-        "@rdfjs/traverser": "^0.1.2",
-        "@tpluscode/rdf-ns-builders": "^4.1.0",
-        "@zazuko/env-core": "^1.1.2",
-        "@zazuko/prefixes": "^2.1.0",
-        "clownface": "^2.0.2",
-        "get-stream": "^9.0.1",
-        "rdf-dataset-ext": "^1.1.0"
-      },
-      "peerDependencies": {
-        "@rdfjs/types": "^2",
-        "@types/clownface": "^2.0.0",
-        "@types/rdf-dataset-ext": "^1.0.8",
-        "@types/rdfjs__data-model": "^2.0.9",
-        "@types/rdfjs__dataset": "^2.0.7",
-        "@types/rdfjs__environment": "^1.0.0",
-        "@types/rdfjs__formats": "^4.0.1",
-        "@types/rdfjs__namespace": "^2.0.10",
-        "@types/rdfjs__term-map": "^2.0.10",
-        "@types/rdfjs__term-set": "^2.0.9",
-        "@types/rdfjs__traverser": "^0.1.5"
-      }
-    },
     "node_modules/@zazuko/env-core": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@zazuko/env-core/-/env-core-1.1.2.tgz",
       "integrity": "sha512-mnLG40utuT7jPBPLs6fJ0puhfagnXSj+S8t9+zUGs3YlrOq/7b2zr64Hi3p3etwDdApaQ0VgQuNIY9doaruS1Q==",
+      "dev": true,
       "dependencies": {
         "@rdfjs/environment": "^1.0.0"
       },
@@ -5958,6 +5960,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/duplex-to/-/duplex-to-2.0.0.tgz",
       "integrity": "sha512-f2nMnk11mwDptEFBTv2mcWHpF4ENAbuQ63yTiSy/99rG4Exsxsf0GJhJYq/AHF2cdMYswSx23LPuoijBflpquQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/duplexer": {
@@ -7647,6 +7650,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
       "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
@@ -8044,6 +8048,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.3.tgz",
       "integrity": "sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -8755,6 +8760,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -9110,6 +9116,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-3.0.0.tgz",
       "integrity": "sha512-Kg6TVtBUdIm057ht/8WNhM9BROt+BeYaDGXbzrKaa3xA99csee+CsD8IMCTizRgzoO8PIzvzcxxCoRvpq1xNQw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-link-header": "^1.0.1",
@@ -9125,6 +9132,7 @@
       "version": "18.19.71",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.71.tgz",
       "integrity": "sha512-evXpcgtZm8FY4jqBSN8+DmOTcVkkvTmAayeo4Wf3m1xAruyVGzGuDh/Fb/WWX2yLItUiho42ozyJjB0dw//Tkw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -9134,12 +9142,14 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonld-streaming-parser": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-5.0.0.tgz",
       "integrity": "sha512-Q6Bfbmig8fFpIbJgJTi4LLzco9dz0YuBM/mDvUYXzP8L/+me6P3pRy4exrhCpv49Bwv2oQFFIHM7wIwCKma2XA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bergos/jsonparse": "^1.4.0",
@@ -11837,6 +11847,7 @@
       "resolved": "https://registry.npmjs.org/rdf-dataset-ext/-/rdf-dataset-ext-1.1.0.tgz",
       "integrity": "sha512-CH85RfRKN9aSlbju8T7aM8hgCSWMBsh2eh/tGxUUtWMN+waxi6iFDt8/r4PAEmKaEA82guimZJ4ISbmJ2rvWQg==",
       "deprecated": "rdf-dataset-ext is deprecated. Switching to rdf-ext is recommended.",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "rdf-canonize": "^3.0.0",
@@ -11916,6 +11927,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.4.0.tgz",
       "integrity": "sha512-f+tdI1wxOiPzMbFWRtOwinwPsqac0WIN80668yFKcVdFCSTGOWTM70ucQGUSdDZZo7pce/UvZgV0C3LDj0P7tg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -11933,6 +11945,7 @@
       "version": "2.3.15",
       "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
       "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -11944,6 +11957,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz",
       "integrity": "sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -12164,6 +12178,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.7.tgz",
       "integrity": "sha512-Xjyl4HmIzg2jzK/Un2gELqbcE8Fxy85A/aLSHE6PE/3+OGsFwmKVA1vRyGaz6vLWSqLDMHA+5rjD/xbibSQN1Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/release-it": {
@@ -13043,6 +13058,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-identifier": {
@@ -13410,6 +13426,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-chunks/-/stream-chunks-1.0.0.tgz",
       "integrity": "sha512-/G+kinLx3pKXChtuko82taA4gZo56zFG2b2BbhmugmS0TUPBL40c5b2vjonS+gAHYK/cSKM9m0WTvAJYgDUeNw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
@@ -14277,6 +14294,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/validate-iri/-/validate-iri-1.0.1.tgz",
       "integrity": "sha512-gLXi7351CoyVVQw8XE5sgpYawRKatxE7kj/xmCxXOZS1kMdtcqC0ILIqLuVEVnAUQSL/evOGG3eQ+8VgbdnstA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/web-streams-polyfill": {
@@ -14755,6 +14773,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@zazuko/env": "^2.4.2",
     "ethers": "^6.15.0",
     "jsonld": "^8.3.3",
     "n3": "^1.23.1",

--- a/package.json
+++ b/package.json
@@ -4,20 +4,23 @@
   "repository": "https://github.com/oceanprotocol/ddo.js.git",
   "author": "Ocean Protocol <devops@oceanprotocol.com>",
   "license": "Apache-2.0",
-  "main": "./dist/ddo.module.js",
-  "umd:main": "dist/ddo.umd.js",
+  "main": "./dist/ddo.cjs",
+  "umd:main": "./dist/ddo.umd.js",
   "module": "./dist/ddo.js",
   "type": "module",
-  "export": {
-    "require": "./dist/ddo.cjs",
-    "import": "./dist/ddo.module.js"
+  "exports": {
+    ".": {
+      "require": "./dist/ddo.cjs",
+      "import": "./dist/ddo.js"
+    }
   },
   "types": "./dist/types/index.d.ts",
   "source": "./src/index.ts",
   "scripts": {
     "lint": "eslint --ignore-path .gitignore --ext .ts,.tsx .",
     "lint:fix": "eslint --ignore-path .gitignore --ext .ts,.tsx . --fix",
-    "build": "npm run clean && microbundle build --format modern,esm,cjs,umd --compress --tsconfig tsconfig.json",
+    "generate:schemas": "node scripts/generate-schemas.js",
+    "build": "npm run clean && npm run generate:schemas && microbundle build --format modern,esm,cjs,umd --compress --tsconfig tsconfig.json",
     "buildesm": "npm run clean && microbundle build --format esm --compress --tsconfig tsconfig.json",
     "build:tsc": "tsc --sourceMap",
     "clean": "rm -rf ./dist/ ./doc/ ./.nyc_output",
@@ -32,22 +35,24 @@
     "@types/mocha": "^10.0.10",
     "@typescript-eslint/eslint-plugin": "^6.4.1",
     "@typescript-eslint/parser": "^6.4.1",
+    "@zazuko/env-node": "^3.0.0",
+    "@zazuko/rdf-utils-fs": "^3.3.1",
     "eslint": "^8.57.0",
     "eslint-config-oceanprotocol": "^2.0.3",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^4.2.1",
     "microbundle": "^0.15.1",
+    "chai": "^5.1.2",
     "mocha": "^11.0.1",
     "prettier": "^2.7.1",
     "release-it": "^18.1.2",
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@rdfjs/formats-common": "^3.1.0",
-    "@types/rdfjs__formats-common": "^3.1.5",
-    "@zazuko/env-node": "^2.1.4",
-    "chai": "^5.1.2",
+    "@zazuko/env": "^2.4.2",
     "ethers": "^6.15.0",
+    "jsonld": "^8.3.3",
+    "n3": "^1.23.1",
     "rdf-literal": "^2.0.0",
     "rdf-validate-shacl": "^0.5.6"
   },

--- a/package.json
+++ b/package.json
@@ -20,14 +20,16 @@
     "lint": "eslint --ignore-path .gitignore --ext .ts,.tsx .",
     "lint:fix": "eslint --ignore-path .gitignore --ext .ts,.tsx . --fix",
     "generate:schemas": "node scripts/generate-schemas.js",
-    "build": "npm run clean && npm run generate:schemas && microbundle build --format modern,esm,cjs,umd --compress --tsconfig tsconfig.json",
+    "prebuild": "npm run generate:schemas",
+    "build": "npm run clean && microbundle build --format modern,esm,cjs,umd --compress --tsconfig tsconfig.json",
     "buildesm": "npm run clean && microbundle build --format esm --compress --tsconfig tsconfig.json",
     "build:tsc": "tsc --sourceMap",
     "clean": "rm -rf ./dist/ ./doc/ ./.nyc_output",
     "mocha": "mocha --node-env=test --config .mocharc.json",
     "clean-tests": "rm -rf ./dist/test",
     "build-tests": "tsc --sourceMap --sourceRoot ./src/test --outDir ./dist",
-    "test:unit": "npm run clean-tests && npm run build-tests && npm run mocha \"./dist/test/**/*.test.js\"",
+    "pretest:unit": "npm run generate:schemas && npm run clean-tests && npm run build-tests",
+    "test:unit": "npm run mocha \"./dist/test/**/*.test.js\"",
     "release": "release-it --non-interactive"
   },
   "devDependencies": {

--- a/scripts/generate-schemas.js
+++ b/scripts/generate-schemas.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync, readdirSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const schemasDir = join(__dirname, '..', 'schemas');
+const outputFile = join(__dirname, '..', 'src', 'schemas', 'index.ts');
+
+const schemaFiles = readdirSync(schemasDir).filter(f => f.endsWith('.ttl'));
+
+if (schemaFiles.length === 0) {
+  console.error('Error: No .ttl files found in', schemasDir);
+  process.exit(1);
+}
+
+let output = `// Auto-generated - DO NOT EDIT
+// Run 'npm run generate:schemas' to regenerate from .ttl files
+
+export const SCHEMAS: Record<string, string> = {\n`;
+
+for (const file of schemaFiles) {
+  const version = file.replace('.ttl', '');
+  const content = readFileSync(join(schemasDir, file), 'utf-8');
+  // Escape for template literal: backslashes first, then backticks and ${
+  const escaped = content.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\${/g, '\\${');
+  output += `  '${version}': \`${escaped}\`,\n\n`;
+}
+
+output += `};\n`;
+
+mkdirSync(dirname(outputFile), { recursive: true });
+writeFileSync(outputFile, output);
+console.log(`Generated ${outputFile} with ${schemaFiles.length} schemas`);

--- a/src/services/ddoManager.ts
+++ b/src/services/ddoManager.ts
@@ -1,6 +1,6 @@
 import { getAddress, sha256, toUtf8Bytes } from 'ethers';
 import { fromRdf } from 'rdf-literal';
-import { Parser as N3Parser } from 'n3';
+import { Parser as N3Parser, Store } from 'n3';
 import jsonld from 'jsonld';
 import { AssetFields } from '../@types/AssetTypes.js';
 import { Service as ServiceV4 } from '../@types/DDO4/Service.js';
@@ -12,7 +12,7 @@ import {
   UpdateFields,
   VersionedDDO
 } from '../@types/index.js';
-import { getRdfjsLibraries } from '../utils/importUtils.js';
+import { getSHACLValidator } from '../utils/importUtils.js';
 import { SCHEMAS } from '../schemas/index.js';
 
 const CURRENT_VERSION = '5.0.0';
@@ -131,11 +131,11 @@ export abstract class DDOManager {
     ddoCopy: Record<string, any>,
     extraErrors: Record<string, string[]>
   ): Promise<{ conforms: boolean; results: any[]; dataset: any } | null> {
-    const { rdf, SHACLValidator } = await getRdfjsLibraries();
+    const SHACLValidator = await getSHACLValidator();
 
     // Parse Turtle schema with n3
     const schemaContent = this.getSchema(ddoCopy.version);
-    const shapes = rdf.dataset(new N3Parser().parse(schemaContent));
+    const shapes = new Store(new N3Parser().parse(schemaContent));
 
     // Parse JSON-LD data: convert to N-Quads, then parse with n3
     let nquads;
@@ -145,9 +145,9 @@ export abstract class DDOManager {
       extraErrors.output = ['Output is null or invalid'];
       return null;
     }
-    const data = rdf.dataset(new N3Parser().parse(nquads as string));
+    const data = new Store(new N3Parser().parse(nquads as string));
 
-    const validator = new SHACLValidator(shapes, { factory: rdf });
+    const validator = new SHACLValidator(shapes);
     return validator.validate(data);
   }
 
@@ -256,9 +256,7 @@ export class V4DDO extends DDOManager {
         extraErrors[key].push(fromRdf(result.message[0]));
       }
     }
-    extraErrors.fullReport = await report.dataset.serialize({
-      format: 'application/ld+json'
-    });
+    extraErrors.fullReport = report.dataset.toString();
     return [false, extraErrors];
   }
 }
@@ -373,9 +371,7 @@ export class V5DDO extends DDOManager {
         extraErrors[key].push(result.message[0].value);
       }
     }
-    extraErrors.fullReport = await report.dataset.serialize({
-      format: 'application/ld+json'
-    });
+    extraErrors.fullReport = report.dataset.toString();
     return [false, extraErrors];
   }
 }
@@ -470,9 +466,7 @@ export class DeprecatedDDO extends DDOManager {
         extraErrors[key].push(fromRdf(result.message[0]));
       }
     }
-    extraErrors.fullReport = await report.dataset.serialize({
-      format: 'application/ld+json'
-    });
+    extraErrors.fullReport = report.dataset.toString();
     return [false, extraErrors];
   }
 }

--- a/src/services/ddoManager.ts
+++ b/src/services/ddoManager.ts
@@ -1,10 +1,7 @@
-import { createHash } from 'crypto';
-import { getAddress } from 'ethers';
-import { dirname, resolve } from 'path';
+import { getAddress, sha256, toUtf8Bytes } from 'ethers';
 import { fromRdf } from 'rdf-literal';
-// @ts-ignore
-import { Readable } from 'stream';
-import { fileURLToPath } from 'url';
+import { Parser as N3Parser } from 'n3';
+import jsonld from 'jsonld';
 import { AssetFields } from '../@types/AssetTypes.js';
 import { Service as ServiceV4 } from '../@types/DDO4/Service.js';
 import { Service as ServiceV5 } from '../@types/DDO5/Service.js';
@@ -15,8 +12,8 @@ import {
   UpdateFields,
   VersionedDDO
 } from '../@types/index.js';
-import { existsSync } from 'fs';
 import { getRdfjsLibraries } from '../utils/importUtils.js';
+import { SCHEMAS } from '../schemas/index.js';
 
 const CURRENT_VERSION = '5.0.0';
 const ALLOWED_VERSIONS = [
@@ -76,11 +73,26 @@ export abstract class DDOManager {
   abstract getAssetFields(): AssetFields;
 
   /**
+   * Abstract method to update multiple fields.
+   * @param fields - Partial object containing fields to update.
+   * @returns The updated DDO data.
+   */
+  abstract updateFields(fields: UpdateFields): Record<string, any>;
+
+  /**
    * Retrieves the DDO data.
    * @returns The DDO data as a record.
    */
   public getDDOData(): Record<string, any> {
     return this.ddoData;
+  }
+
+  /**
+   * Method to retrieve the DID.
+   * @returns The DID of ddo.
+   */
+  public getDid(): string {
+    return this.getDDOData().id || null;
   }
 
   public deleteIndexedMetadataIfExists(
@@ -95,40 +107,48 @@ export abstract class DDOManager {
   }
 
   /**
-   * Abstract method to update multiple fields.
-   * @param fields - Partial object containing fields to update.
-   * @returns The updated DDO data.
-   */
-  abstract updateFields(fields: UpdateFields): Record<string, any>;
-
-  /**
-   * Method to retrieve the DID.
-   * @returns The DID of ddo.
-   */
-  public getDid(): string {
-    return this.getDDOData().id || null;
-  }
-
-  /**
-   * Resolves the schema file path for a given version.
+   * Returns the SHACL schema content for a given version.
    * @param version - The schema version (default: CURRENT_VERSION).
-   * @returns The resolved schema file path.
+   * @returns The schema content as a string.
    * @throws An error if the version is not supported.
    */
   public getSchema(version: string = CURRENT_VERSION): string {
     if (!ALLOWED_VERSIONS.includes(version)) {
       throw new Error(`Unsupported schema version: ${version}`);
     }
-
-    const currentModulePath = fileURLToPath(import.meta.url);
-    const currentDirectory = dirname(currentModulePath);
-
-    const schemaPath = resolve(currentDirectory, `../schemas/${version}.ttl`);
-    if (existsSync(schemaPath)) {
-      return schemaPath;
+    const schema = SCHEMAS[version];
+    if (!schema) {
+      throw new Error(`Schema not found for version: ${version}`);
     }
+    return schema;
+  }
 
-    return resolve(currentDirectory, `../../schemas/${version}.ttl`);
+  /**
+   * Parses schema and data, runs SHACL validation.
+   * @returns Validation report or null if parsing failed (errors added to extraErrors).
+   */
+  protected async runShaclValidation(
+    ddoCopy: Record<string, any>,
+    extraErrors: Record<string, string[]>
+  ): Promise<{ conforms: boolean; results: any[]; dataset: any } | null> {
+    const { rdf, SHACLValidator } = await getRdfjsLibraries();
+
+    // Parse Turtle schema with n3
+    const schemaContent = this.getSchema(ddoCopy.version);
+    const shapes = rdf.dataset(new N3Parser().parse(schemaContent));
+
+    // Parse JSON-LD data: convert to N-Quads, then parse with n3
+    let nquads;
+    try {
+      nquads = await jsonld.toRDF(ddoCopy, { format: 'application/n-quads' });
+    } catch {
+      extraErrors.output = ['Output is null or invalid'];
+      return null;
+    }
+    const data = rdf.dataset(new N3Parser().parse(nquads as string));
+
+    const validator = new SHACLValidator(shapes, { factory: rdf });
+    return validator.validate(data);
   }
 
   /**
@@ -156,6 +176,12 @@ export class V4DDO extends DDOManager {
     super(ddoData);
   }
 
+  makeDid(nftAddress: string, chainId: string): string {
+    return (
+      'did:op:' + sha256(toUtf8Bytes(getAddress(nftAddress) + chainId)).slice(2)
+    );
+  }
+
   getDDOFields(): DDOFields {
     const data = this.getDDOData();
     return {
@@ -174,15 +200,6 @@ export class V4DDO extends DDOManager {
       indexedMetadata: this.getDDOData().indexedMetadata,
       datatokens: this.getDDOData().datatokens
     };
-  }
-
-  makeDid(nftAddress: string, chainId: string): string {
-    return (
-      'did:op:' +
-      createHash('sha256')
-        .update(getAddress(nftAddress) + chainId)
-        .digest('hex')
-    );
   }
 
   updateFields(fields: UpdateFields): Record<string, any> {
@@ -205,45 +222,33 @@ export class V4DDO extends DDOManager {
   }
 
   async validate(): Promise<[boolean, Record<string, string[]>]> {
-    const { rdf, formats, SHACLValidator } = await getRdfjsLibraries();
     const updatedDdo = this.deleteIndexedMetadataIfExists(this.getDDOData());
     const ddoCopy = JSON.parse(JSON.stringify(updatedDdo));
     const { chainId, nftAddress } = ddoCopy;
     const extraErrors: Record<string, string[]> = {};
+
     ddoCopy['@type'] = 'DDO';
-    ddoCopy['@context'] = {
-      '@vocab': 'http://schema.org/'
-    };
+    ddoCopy['@context'] = { '@vocab': 'http://schema.org/' };
+
     if (!chainId) {
-      if (!('chainId' in extraErrors)) extraErrors.chainId = [];
-      extraErrors.chainId.push('chainId is missing or invalid.');
+      extraErrors.chainId = ['chainId is missing or invalid.'];
     }
 
     try {
       getAddress(nftAddress);
-    } catch (err) {
-      if (!('nftAddress' in extraErrors)) extraErrors.nftAddress = [];
-      extraErrors.nftAddress.push('nftAddress is missing or invalid.');
+    } catch {
+      extraErrors.nftAddress = ['nftAddress is missing or invalid.'];
     }
 
-    if (!(this.makeDid(nftAddress, chainId.toString(10)) === ddoCopy.id)) {
-      if (!('id' in extraErrors)) extraErrors.id = [];
-      extraErrors.id.push('did is not valid for chain Id and nft address');
+    if (this.makeDid(nftAddress, chainId.toString(10)) !== ddoCopy.id) {
+      extraErrors.id = ['did is not valid for chain Id and nft address'];
     }
-    const schemaFilePath = this.getSchema(ddoCopy.version);
-    const shapes = await rdf.dataset().import(rdf.fromFile(schemaFilePath));
-    const dataStream = Readable.from(JSON.stringify(ddoCopy));
-    const output = formats.parsers.import('application/ld+json', dataStream);
-    if (!output) {
-      extraErrors.output = ['Output is null or invalid'];
-      return [false, extraErrors];
-    }
-    const data = await rdf.dataset().import(output);
-    const validator = new SHACLValidator(shapes, { factory: rdf });
-    const report = await validator.validate(data);
-    if (report.conforms) {
-      return [true, {}];
-    }
+
+    const report = await this.runShaclValidation(ddoCopy, extraErrors);
+    if (!report) return [false, extraErrors];
+
+    if (report.conforms) return [true, {}];
+
     for (const result of report.results) {
       const key = result.path?.value.replace('http://schema.org/', '');
       if (key) {
@@ -267,9 +272,7 @@ export class V5DDO extends DDOManager {
   makeDid(nftAddress: string, chainId: string): string {
     return (
       'did:ope:' +
-      createHash('sha256')
-        .update(getAddress(nftAddress) + chainId)
-        .digest('hex')
+      sha256(toUtf8Bytes(getAddress(nftAddress) + chainId)).slice(2)
     );
   }
 
@@ -325,26 +328,25 @@ export class V5DDO extends DDOManager {
   }
 
   async validate(): Promise<[boolean, Record<string, string[]>]> {
-    const { rdf, formats, SHACLValidator } = await getRdfjsLibraries();
     const updatedDdo = this.deleteIndexedMetadataIfExists(this.getDDOData());
     const ddoCopy = JSON.parse(JSON.stringify(updatedDdo));
     const { chainId, nftAddress } = ddoCopy.credentialSubject;
     const extraErrors: Record<string, string[]> = {};
+
     ddoCopy['@type'] = 'VerifiableCredential';
-    ddoCopy['@context'] = {
-      '@vocab': 'https://www.w3.org/ns/credentials/v2/'
-    };
+    ddoCopy['@context'] = { '@vocab': 'https://www.w3.org/ns/credentials/v2/' };
+
     if (!ddoCopy.credentialSubject.chainId) {
       extraErrors.chainId = ['chainId is missing or invalid.'];
     }
 
     try {
       getAddress(nftAddress);
-    } catch (err) {
+    } catch {
       extraErrors.nftAddress = ['nftAddress is missing or invalid.'];
     }
 
-    if (!(this.makeDid(nftAddress, chainId.toString(10)) === ddoCopy.id)) {
+    if (this.makeDid(nftAddress, chainId.toString(10)) !== ddoCopy.id) {
       extraErrors.id = ['did is not valid for chainId and nft address'];
     }
 
@@ -356,22 +358,10 @@ export class V5DDO extends DDOManager {
       extraErrors.services = ['services are missing or invalid.'];
     }
 
-    const schemaFilePath = this.getSchema(ddoCopy.version);
+    const report = await this.runShaclValidation(ddoCopy, extraErrors);
+    if (!report) return [false, extraErrors];
 
-    const shapes = await rdf.dataset().import(rdf.fromFile(schemaFilePath));
-    const dataStream = Readable.from(JSON.stringify(ddoCopy));
-    const output = formats.parsers.import('application/ld+json', dataStream);
-    if (!output) {
-      extraErrors.output = ['Output is null or invalid'];
-      return [false, extraErrors];
-    }
-    const data = await rdf.dataset().import(output);
-    const validator = new SHACLValidator(shapes, { factory: rdf });
-    const report = await validator.validate(data);
-
-    if (report.conforms) {
-      return [true, {}];
-    }
+    if (report.conforms) return [true, {}];
 
     for (const result of report.results) {
       const key = result?.path?.value.replace(
@@ -383,7 +373,6 @@ export class V5DDO extends DDOManager {
         extraErrors[key].push(result.message[0].value);
       }
     }
-
     extraErrors.fullReport = await report.dataset.serialize({
       format: 'application/ld+json'
     });
@@ -399,10 +388,7 @@ export class DeprecatedDDO extends DDOManager {
 
   makeDid(nftAddress: string, chainId: string): string {
     return (
-      'did:op:' +
-      createHash('sha256')
-        .update(getAddress(nftAddress) + chainId)
-        .digest('hex')
+      'did:op:' + sha256(toUtf8Bytes(getAddress(nftAddress) + chainId)).slice(2)
     );
   }
 
@@ -433,7 +419,6 @@ export class DeprecatedDDO extends DDOManager {
       created: null,
       tokenURI: null
     };
-
     return {
       indexedMetadata,
       datatokens: null
@@ -451,45 +436,33 @@ export class DeprecatedDDO extends DDOManager {
   }
 
   async validate(): Promise<[boolean, Record<string, string[]>]> {
-    const { rdf, formats, SHACLValidator } = await getRdfjsLibraries();
     const updatedDdo = this.deleteIndexedMetadataIfExists(this.getDDOData());
     const ddoCopy = JSON.parse(JSON.stringify(updatedDdo));
     const { chainId, nftAddress } = ddoCopy;
     const extraErrors: Record<string, string[]> = {};
+
     ddoCopy['@type'] = 'DDO';
-    ddoCopy['@context'] = {
-      '@vocab': 'http://schema.org/'
-    };
+    ddoCopy['@context'] = { '@vocab': 'http://schema.org/' };
+
     if (!chainId) {
-      if (!('chainId' in extraErrors)) extraErrors.chainId = [];
-      extraErrors.chainId.push('chainId is missing or invalid.');
+      extraErrors.chainId = ['chainId is missing or invalid.'];
     }
 
     try {
       getAddress(nftAddress);
-    } catch (err) {
-      if (!('nftAddress' in extraErrors)) extraErrors.nftAddress = [];
-      extraErrors.nftAddress.push('nftAddress is missing or invalid.');
+    } catch {
+      extraErrors.nftAddress = ['nftAddress is missing or invalid.'];
     }
 
-    if (!(this.makeDid(nftAddress, chainId.toString(10)) === ddoCopy.id)) {
-      if (!('id' in extraErrors)) extraErrors.id = [];
-      extraErrors.id.push('did is not valid for chain Id and nft address');
+    if (this.makeDid(nftAddress, chainId.toString(10)) !== ddoCopy.id) {
+      extraErrors.id = ['did is not valid for chain Id and nft address'];
     }
-    const schemaFilePath = this.getSchema(ddoCopy.version);
-    const shapes = await rdf.dataset().import(rdf.fromFile(schemaFilePath));
-    const dataStream = Readable.from(JSON.stringify(ddoCopy));
-    const output = formats.parsers.import('application/ld+json', dataStream);
-    if (!output) {
-      extraErrors.output = ['Output is null or invalid'];
-      return [false, extraErrors];
-    }
-    const data = await rdf.dataset().import(output);
-    const validator = new SHACLValidator(shapes, { factory: rdf });
-    const report = await validator.validate(data);
-    if (report.conforms) {
-      return [true, {}];
-    }
+
+    const report = await this.runShaclValidation(ddoCopy, extraErrors);
+    if (!report) return [false, extraErrors];
+
+    if (report.conforms) return [true, {}];
+
     for (const result of report.results) {
       const key = result.path?.value.replace('http://schema.org/', '');
       if (key) {

--- a/src/utils/importUtils.ts
+++ b/src/utils/importUtils.ts
@@ -1,17 +1,11 @@
-let rdf;
-let SHACLValidator;
-let formats;
+let rdf: any;
+let SHACLValidator: any;
 
 export const getRdfjsLibraries = async () => {
-  if (!formats) {
-    const formatsModule = await import('@rdfjs/formats-common');
-    formats = formatsModule.default;
-  }
-
   if (!rdf) {
-    const envNode = await import('@zazuko/env-node');
-    rdf = envNode.default;
-    rdf.formats.import(formats);
+    // Browser-compatible RDF environment (no filesystem access needed)
+    const envModule = await import('@zazuko/env');
+    rdf = envModule.default;
   }
 
   if (!SHACLValidator) {
@@ -19,5 +13,5 @@ export const getRdfjsLibraries = async () => {
     SHACLValidator = shaclModule.default;
   }
 
-  return { formats, rdf, SHACLValidator };
+  return { rdf, SHACLValidator };
 };

--- a/src/utils/importUtils.ts
+++ b/src/utils/importUtils.ts
@@ -1,17 +1,9 @@
-let rdf: any;
 let SHACLValidator: any;
 
-export const getRdfjsLibraries = async () => {
-  if (!rdf) {
-    // Browser-compatible RDF environment (no filesystem access needed)
-    const envModule = await import('@zazuko/env');
-    rdf = envModule.default;
-  }
-
+export const getSHACLValidator = async () => {
   if (!SHACLValidator) {
-    const shaclModule = await import('rdf-validate-shacl');
-    SHACLValidator = shaclModule.default;
+    const module = await import('rdf-validate-shacl');
+    SHACLValidator = module.default;
   }
-
-  return { rdf, SHACLValidator };
+  return SHACLValidator;
 };


### PR DESCRIPTION
Fixes https://github.com/oceanprotocol/ocean.js/issues/2063

Changes proposed in this PR:

 Browser compatibility fix for SHACL validation.

- Replace stream-based RDF parsing (`@rdfjs/formats-common`) with `n3` + `jsonld`
- Remove Node.js dependencies: `crypto`, `fs`, `stream`, `path`, `url`
- Use `ethers.sha256` instead of Node's `crypto.createHash`
- Embed TTL schemas at build time via `scripts/generate-schemas.js`
- Fix package.json: `export` -> `exports`, correct entry points